### PR TITLE
fix: add GLFW3 and GLFW_INCLUDE_GLCOREARB, remove glewinit for mac

### DIFF
--- a/src/VRMenu.cpp
+++ b/src/VRMenu.cpp
@@ -37,6 +37,11 @@
 #include "GL/glxew.h"
 #endif
 
+#ifdef __APPLE__
+#define GLFW_INCLUDE_GLCOREARB
+#include <GLFW/glfw3.h>
+#endif
+
 #include "VRMenu.h"
 
 // OpenGL platform-specific headers
@@ -167,7 +172,10 @@ void VRMenu::renderToTexture()
 	if (!m_glew_initialised)
 	{
 		std::cerr << "Init glew" << std::endl;
+
+		#ifndef __APPLE__
 		glewInit();
+		#endif
 		m_glew_initialised = true;
 	}
 


### PR DESCRIPTION
fixes for the following errors I ran into trying to build VR-imgui on mac

**undeclared identifier 'glewInit'**

```
/Users/ellen/Documents/Projects/VR-imgui/src/VRMenu.cpp:170:3: error: use of undeclared identifier 'glewInit'
                glewInit();
                ^
```

Fix: [glewInit() fails on macOS](https://stackoverflow.com/questions/11212347/glewinit-fails-on-macos/11213354)


**undeclared identifier 'GL_TEXTURE_2D_MULTISAMPLE'**

```
/Users/ellen/Documents/Projects/VR-imgui/src/VRMenu.cpp:119:17: error: use of undeclared identifier 'GL_TEXTURE_2D_MULTISAMPLE'
                glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, m_nRenderTextureId);
                              ^
/Users/ellen/Documents/Projects/VR-imgui/src/VRMenu.cpp:120:27: error: use of undeclared identifier 'GL_TEXTURE_2D_MULTISAMPLE'
                glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, 4, GL_RGBA8, m_res_x, m_res_y, true);
                                        ^
/Users/ellen/Documents/Projects/VR-imgui/src/VRMenu.cpp:121:64: error: use of undeclared identifier 'GL_TEXTURE_2D_MULTISAMPLE'
                glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, m_nRenderTextureId, 0);
```

Fix: [OpenGL Functions not defined OSX](https://stackoverflow.com/questions/24725781/opengl-functions-not-defined-osx)